### PR TITLE
Allow support for the helper networkifacename being "System eno1"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -310,10 +310,10 @@
       mode: '0555'
 
   - name: Setting DNS server ip on network interface "{{ helper.networkifacename }}" to 127.0.0.1
-    command: "nmcli con mod {{ helper.networkifacename }}  ipv4.dns 127.0.0.1"
+    command: "nmcli con mod '{{ helper.networkifacename }}'  ipv4.dns 127.0.0.1"
 
   - name: Setting DNS search path on network interface "{{ helper.networkifacename }}" to "{{ dns.clusterid }}.{{ dns.domain }}"
-    command: "nmcli con mod {{ helper.networkifacename }}  ipv4.dns-search {{ dns.clusterid }}.{{ dns.domain }}"
+    command: "nmcli con mod '{{ helper.networkifacename }}'  ipv4.dns-search {{ dns.clusterid }}.{{ dns.domain }}"
 
   - name: Restarting NetworkManager
     service:

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -10,7 +10,7 @@ max-lease-time 14400;
 	option domain-name              "{{ dns.clusterid }}.{{ dns.domain }}";
 
 	subnet {{ dhcp.ipid }} netmask {{ dhcp.netmaskid }} {
-	interface {{ helper.networkifacename }};
+	interface {{ helper.networkifacename.split(' ')[-1] }};
      	pool {
         	range {{ dhcp.poolstart }} {{ dhcp.poolend }};
 		# Static entries


### PR DESCRIPTION
On my test machine, `nmcli` shows the following onboard interface `System eno1` .. 

```
# nmcli con | egrep "NAME|eno1"
NAME           UUID                                  TYPE      DEVICE
System eno1    4ce552e9-6e33-4303-95e3-16c41e5b2a12  ethernet  eno1
```

So running `nmcli con mod eno1..` results in unknown interface.   But `/etc/dhcp/dhcpd.conf` can't take that "System eno1"  so I split it...    

After the playbook is run, it succeeds, and the `dhcp.config` looks like this: 
```
# grep eno1 /etc/dhcp/dhcpd.conf
	interface eno1;
```

To test the original case where someone just sets eth0 or eno1...   I just ran a simple debug msg: `msg: "helper '{{ helper.networkifacename.split(' ')[-1] }}` 

Here's the changes
```
$ git grep ifacename
environments/c910env/group_vars/main.yml:  networkifacename: "eno1" <---- 
roles/debug/tasks/main.yml:    msg: "helper '{{ helper.networkifacename.split(' ')[-1] }}"
```

And the results: 
```
TASK [debug : debug] ********************************************************************************************************
ok: [c910f04x40] => {
    "msg": "helper 'eno1"
}

```