### PR TITLE
ocp4 is the dns.clusterid, so remove the hard code of ocp4 in reverse dns template

### DIFF
--- a/templates/reverse.j2
+++ b/templates/reverse.j2
@@ -14,8 +14,8 @@ $TTL 1W
 ;
 {{ bootstrap.ipaddr.split('.')[3] }}	IN	PTR	{{ bootstrap.name }}.{{ dns.clusterid }}.{{ dns.domain }}.
 ;
-{{ helper.ipaddr.split('.')[3] }}	IN	PTR	api.ocp4.{{ dns.clusterid }}.{{ dns.domain }}.
-{{ helper.ipaddr.split('.')[3] }}	IN	PTR	api-int.ocp4.{{ dns.clusterid }}.{{ dns.domain }}.
+{{ helper.ipaddr.split('.')[3] }}	IN	PTR	api.{{ dns.clusterid }}.{{ dns.domain }}.
+{{ helper.ipaddr.split('.')[3] }}	IN	PTR	api-int.{{ dns.clusterid }}.{{ dns.domain }}.
 ;
 {% for w in workers %}
 {{ w.ipaddr.split('.')[3] }}	IN	PTR	{{ w.name }}.{{ dns.clusterid }}.{{ dns.domain }}.


### PR DESCRIPTION
Small change, not sure if this really has any effect in DNS.... but to be correct the ocp4 should not be hard code...

Running this change:
```
[root@helper ocp4-upi-helpernode]# grep helper templates/reverse.j2
{{ helper.ipaddr.split('.')[3] }}	IN	PTR	api.{{ dns.clusterid }}.{{ dns.domain }}.
{{ helper.ipaddr.split('.')[3] }}	IN	PTR	api-int.{{ dns.clusterid }}.{{ dns.domain }}.
```

Results in 
```
[root@helper ocp4-upi-helpernode]# grep api /var/named/reverse.db
1	IN	PTR	api.ocp4-2.pok.stglabs.ibm.com.
1	IN	PTR	api-int.ocp4-2.pok.stglabs.ibm.com.
```
