### PR TITLE
Create a variable to cleanup ocp4 files to have get_url download them again 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,6 @@
       url: "{{ ocp_bios}}"
       dest: /var/www/html/install/bios.raw.gz
       mode: 0555
-      force: true
 
   - name: Open up firewall ports
     firewalld:
@@ -185,7 +184,6 @@
       url: "{{ ocp_initramfs }}"
       dest: /var/lib/tftpboot/rhcos/initramfs.img
       mode: 0555
-      force: true
     when: not staticips
 
   - name: Downloading OCP4 installer kernel
@@ -302,17 +300,27 @@
       group: root
       mode: 0555
 
+  - name: Delete OCP4 files, if requested, to download again
+    file:
+       state: absent
+       path: "{{ item }}"
+    with_items: 
+      - "/usr/local/src/openshift-client-linux.tar.gz"
+      - "/usr/local/src/openshift-install-linux.tar.gz" 
+      - "/var/www/html/install/bios.raw.gz"
+      - "/var/lib/tftpboot/rhcos/initramfs.img"
+      - "/var/lib/tftpboot/rhcos/kernel"
+    when: force_download is true
+
   - name: Downloading OCP4 client
     get_url:
       url: "{{ ocp_client }}"
       dest: /usr/local/src/openshift-client-linux.tar.gz
-      force: true
 
   - name: Downloading OCP4 Installer
     get_url:
       url: "{{ ocp_installer }}"
       dest: /usr/local/src/openshift-install-linux.tar.gz
-      force: true
 
   - name: Unarchiving OCP4 client
     unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,7 +97,7 @@
       - /var/www/html/install
       - /var/www/html/ignition
 
-  - name: Get OCP4 installer Bios
+  - name: Downloading OCP4 installer Bios
     get_url:
       url: "{{ ocp_bios}}"
       dest: /var/www/html/install/bios.raw.gz
@@ -179,14 +179,14 @@
     shell: "cp -a /usr/share/syslinux/* /var/lib/tftpboot"
     when: not staticips
 
-  - name: Get OCP4 installer initramfs
+  - name: Downloading OCP4 installer initramfs
     get_url:
       url: "{{ ocp_initramfs }}"
       dest: /var/lib/tftpboot/rhcos/initramfs.img
       mode: 0555
     when: not staticips
 
-  - name: Get OCP4 installer kernel
+  - name: Downloading OCP4 installer kernel
     get_url:
       url: "{{ ocp_install_kernel }}"
       dest: /var/lib/tftpboot/rhcos/kernel
@@ -300,23 +300,23 @@
       group: root
       mode: 0555
 
-  - name: Dowloading OC clients 
+  - name: Downloading OCP4 client
     get_url:
       url: "{{ ocp_client }}"
       dest: /usr/local/src/openshift-client-linux.tar.gz
 
-  - name: Dowloading OpenShift Installer
+  - name: Downloading OCP4 Installer
     get_url:
       url: "{{ ocp_installer }}"
       dest: /usr/local/src/openshift-install-linux.tar.gz
 
-  - name: Unarchiving OC clients
+  - name: Unarchiving OCP4 client
     unarchive:
       src: /usr/local/src/openshift-client-linux.tar.gz
       dest: /usr/local/bin
       remote_src: yes
 
-  - name: Unarchiving OpenShift Installer
+  - name: Unarchiving OCP4 Installer
     unarchive:
       src: /usr/local/src/openshift-install-linux.tar.gz
       dest: /usr/local/bin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,6 +97,18 @@
       - /var/www/html/install
       - /var/www/html/ignition
 
+  - name: Delete OCP4 files, if requested, to download again
+    file:
+       state: absent
+       path: "{{ item }}"
+    with_items: 
+      - "/usr/local/src/openshift-client-linux.tar.gz"
+      - "/usr/local/src/openshift-install-linux.tar.gz" 
+      - "/var/www/html/install/bios.raw.gz"
+      - "/var/lib/tftpboot/rhcos/initramfs.img"
+      - "/var/lib/tftpboot/rhcos/kernel"
+    when: force_download 
+
   - name: Downloading OCP4 installer Bios
     get_url:
       url: "{{ ocp_bios}}"
@@ -299,18 +311,6 @@
       owner: root
       group: root
       mode: 0555
-
-  - name: Delete OCP4 files, if requested, to download again
-    file:
-       state: absent
-       path: "{{ item }}"
-    with_items: 
-      - "/usr/local/src/openshift-client-linux.tar.gz"
-      - "/usr/local/src/openshift-install-linux.tar.gz" 
-      - "/var/www/html/install/bios.raw.gz"
-      - "/var/lib/tftpboot/rhcos/initramfs.img"
-      - "/var/lib/tftpboot/rhcos/kernel"
-    when: force_download is true
 
   - name: Downloading OCP4 client
     get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,7 +107,7 @@
       - "/var/www/html/install/bios.raw.gz"
       - "/var/lib/tftpboot/rhcos/initramfs.img"
       - "/var/lib/tftpboot/rhcos/kernel"
-    when: force_download 
+    when: force_ocp_download 
 
   - name: Downloading OCP4 installer Bios
     get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,7 @@
       url: "{{ ocp_bios}}"
       dest: /var/www/html/install/bios.raw.gz
       mode: 0555
+      force: true
 
   - name: Open up firewall ports
     firewalld:
@@ -184,6 +185,7 @@
       url: "{{ ocp_initramfs }}"
       dest: /var/lib/tftpboot/rhcos/initramfs.img
       mode: 0555
+      force: true
     when: not staticips
 
   - name: Downloading OCP4 installer kernel
@@ -304,11 +306,13 @@
     get_url:
       url: "{{ ocp_client }}"
       dest: /usr/local/src/openshift-client-linux.tar.gz
+      force: true
 
   - name: Downloading OCP4 Installer
     get_url:
       url: "{{ ocp_installer }}"
       dest: /usr/local/src/openshift-install-linux.tar.gz
+      force: true
 
   - name: Unarchiving OCP4 client
     unarchive:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,8 +2,8 @@
 # vars file for tester
 staticips: false
 
-# Set this to true to force download of the files
-force_download: false
+# Set to true to clean and re-download ocp files
+force_ocp_download: false
 ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0/rhcos-4.1.0-x86_64-metal-bios.raw.gz"
 ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0/rhcos-4.1.0-x86_64-installer-initramfs.img"
 ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0/rhcos-4.1.0-x86_64-installer-kernel"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,9 @@
 ---
 # vars file for tester
 staticips: false
+
+# Set this to true to force download of the files
+force_download: false
 ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0/rhcos-4.1.0-x86_64-metal-bios.raw.gz"
 ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0/rhcos-4.1.0-x86_64-installer-initramfs.img"
 ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.1/4.1.0/rhcos-4.1.0-x86_64-installer-kernel"


### PR DESCRIPTION
Running the playbook over itself, just modifying the URLs does not invoke the download to happen again.   

I guess this is why you asked for a cleanup option to be created.  But for the near term, offer this patch... 

Changes: 
* cleaned up the name so I could do `git grep Download` to more easily find the download tasks
* add a `force_ocp_download` variable to delete the  files, causing the `get_url` to download them again.