### PR TITLE
Adding firewalld package as prereq

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
       name:
         - bind
         - bind-utils
+        - firewalld
         - haproxy
         - httpd
         - vim


### PR DESCRIPTION
Firewalld module is used later in the playbook, so it should be validated that the package is installed